### PR TITLE
verify state isn't specified before returning 0

### DIFF
--- a/lib/app/nagiosfoundation/servicestatus.go
+++ b/lib/app/nagiosfoundation/servicestatus.go
@@ -96,7 +96,7 @@ func (i *serviceInfo) ProcessInfo() (string, int) {
 	)
 
 	if !i.IsName(i.desiredName) {
-		if i.currentStateWanted {
+		if i.currentStateWanted && i.desiredState == "" {
 			nagiosInfo = fmt.Sprintf("%s=255 service_name=%s", i.metricName, i.desiredName)
 			retcode = 0
 		} else {


### PR DESCRIPTION
If a state is specified, we always want to return failing because there is no desired state that can match DNE